### PR TITLE
wahoo: Enable IORap app launch prefetching

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -780,6 +780,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     NowPlayingOverlay
 
+# IORap app launch prefetching using Perfetto traces and madvise
+PRODUCT_PRODUCT_PROPERTIES += \
+    ro.iorapd.enable=true
+
 include hardware/google/pixel/vibrator/drv2624/device.mk
 include hardware/google/pixel/mm/device_legacy.mk
 include hardware/google/pixel/thermal/device.mk

--- a/overlay/packages/apps/SimpleDeviceConfig/res/values/config.xml
+++ b/overlay/packages/apps/SimpleDeviceConfig/res/values/config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="configs_device">
+        <!-- Allow more cached apps in the background -->
+        <item>activity_manager/max_cached_processes=64</item>
+
+        <!-- ART heap compaction for cached apps -->
+        <item>activity_manager/use_compaction=true</item>
+        
+        <!-- Screen attention -->
+        <item>device_personalization_services/Attention__accel_sensor_enabled=false</item>
+        <item>device_personalization_services/Attention__accel_sensor_threshold_mss=0.2</item>
+        <item>device_personalization_services/Attention__enabled=true</item>
+        <item>device_personalization_services/Attention__margin_horizontal_px=1000</item>
+        <item>device_personalization_services/Attention__margin_vertical_px=1000</item>
+        <item>device_personalization_services/Attention__proximity_sensor_enabled=false</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
Commit b73d5516136d1a4de39afd74f564daf70b946889 in build/make (rvc-qpr2)
disabled IORap by default due to a "regression" without mentioning what
the regression is. Considering how it's been working fine for the past 6
months and has demonstrated improvements to app launch time [1], let's
re-enable it here.

[1] https://medium.com/androiddevelopers/improving-app-startup-with-i-o-prefetching-62fbdb9c9020