### PR TITLE
wahoo: Correct the slot ID of non-removable esim

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/arrays.xml
+++ b/overlay/frameworks/base/core/res/res/values/arrays.xml
@@ -33,6 +33,6 @@
          This is used to differentiate between removable eUICCs and built in eUICCs, and should
          be set by OEMs for devices which use eUICCs. -->
     <integer-array name="non_removable_euicc_slots">
-        <item>1</item>
+        <item>0</item>
     </integer-array>
 </resources>


### PR DESCRIPTION
* According to the instructions attached, when a device with a category has 2 SIM slots, the ID slot is set to number 1, while walleye & taimen only have 1 SIM slot, so it should be set to number 0

* Also it seems fix the random issue lose SIM after restar the system, I have never lost my SIM again after restarting during my personal use, even restarting the device several times

* Logs:

07-06 03:48:28.982  5976  6039 E AndroidRuntime: FATAL EXCEPTION: AsyncTask
07-06 03:48:28.982  5976  6039 E AndroidRuntime: Process: com.google.android.euicc, PID: 5976
07-06 03:48:28.982  5976  6039 E AndroidRuntime: java.lang.RuntimeException: An error occurred while executing doInBackground()
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.os.AsyncTask$4.done(AsyncTask.java:415)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:381)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at java.util.concurrent.FutureTask.setException(FutureTask.java:250)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at java.util.concurrent.FutureTask.run(FutureTask.java:269)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:1012)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: Caused by: java.lang.IllegalArgumentException: Both subId and slotIndex in request are invalid.
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.os.Parcel.createExceptionOrNull(Parcel.java:3015)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.os.Parcel.createException(Parcel.java:2995)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:2978)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:2920)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.android.internal.telephony.ITelephony$Stub$Proxy.iccOpenLogicalChannel(ITelephony.java:8879)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.telephony.TelephonyManager.iccOpenLogicalChannel(TelephonyManager.java:7105)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.telephony.TelephonyManager.iccOpenLogicalChannel(TelephonyManager.java:6922)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.android.euicc.telephony.UiccLogicalChannel.openChannel(UiccLogicalChannel.java:281)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.android.euicc.telephony.UiccLogicalChannel.open(UiccLogicalChannel.java:253)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.android.euicc.telephony.UiccLogicalChannel.open(UiccLogicalChannel.java:104)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.android.euicc.telephony.UiccLogicalChannel.openIsdR(UiccLogicalChannel.java:117)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.google.android.euicc.pixel.telephony.QcrilUiccSlotsManager.getPhysicalSlotsStatus(QcrilUiccSlotsManager.java:137)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.android.euicc.receiver.RestoreUiccSlotSettingsOnBootReceiver$1.doInBackground(RestoreUiccSlotSettingsOnBootReceiver.java:58)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at com.android.euicc.receiver.RestoreUiccSlotSettingsOnBootReceiver$1.doInBackground(RestoreUiccSlotSettingsOnBootReceiver.java:51)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at android.os.AsyncTask$3.call(AsyncTask.java:394)
07-06 03:48:28.982  5976  6039 E AndroidRuntime: 	at java.util.concurrent.FutureTask.run(FutureTask.java:264)